### PR TITLE
Disable submit button when text input is empty

### DIFF
--- a/src/components/MisinformationDetector.test.jsx
+++ b/src/components/MisinformationDetector.test.jsx
@@ -14,6 +14,14 @@ afterEach(() => {
   cleanup();
 });
 
+test('submit button is disabled when input box is empty', () => {
+  render(<MisinformationDetector user="" />);
+  const submitButton = screen.getByTestId(
+    'misinformation-detector-submit-button'
+  );
+  expect(submitButton).toHaveAttribute('disabled');
+});
+
 test('profanity detector detects profanity', () => {
   render(<MisinformationDetector user="" />);
   const textInput = screen.getByRole('textbox');

--- a/src/components/MisinformationDetector.tsx
+++ b/src/components/MisinformationDetector.tsx
@@ -83,7 +83,12 @@ const misinformationAlert = (
   </Alert>
 );
 
-const countWords = (input: string) => input.trim().split(/\s+/).length;
+const countWords = (input: string) => {
+  if (input === '') {
+    return 0;
+  }
+  return input.trim().split(/\s+/).length;
+};
 
 interface MisinformationDetectorProps {
   user: string;
@@ -183,7 +188,9 @@ function MisinformationDetector(props: MisinformationDetectorProps) {
                 marginRight: '8px',
               }}
               disabled={
-                containsProfanity(text) || countWords(text) > MAX_WORD_COUNT
+                containsProfanity(text) ||
+                countWords(text) > MAX_WORD_COUNT ||
+                countWords(text) <= 0
               }
               onClick={submit}
             >


### PR DESCRIPTION
Fixes issue where word count is off by one for empty submission. Prevents users from submitting requests when the input field is empty.

See issue #2.